### PR TITLE
Upgrade main.tf to use with Terraform v0.13

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,13 @@
 #
 # https://www.terraform.io/docs/providers/docker/index.html
 
-provider "docker" {
-  version = "2.7"
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    docker = {
+      source = "terraform-providers/docker"
+      version = "2.7.2"
+    }
+  }
 }


### PR DESCRIPTION
The terraform v0.13 needs explicit provider source locations.
Add that to the new `required_providers` block.

Ref: https://www.terraform.io/upgrade-guides/0-13.html

This commit fixes #2