### PR TITLE
adding a helpful comment about Win vs. Mac

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,5 +12,6 @@ terraform {
 }
 
 provider "docker" {
+  # this setting is only needed on Windows; comment it for MacOS
   host    = "npipe:////.//pipe//docker_engine"
 }


### PR DESCRIPTION
As a Mac user, I got temporarily stuck on this Hashicorp tutorial:
https://learn.hashicorp.com/tutorials/terraform/state-import#import-the-container-into-terraform 

, I had to dig a bit to figure out that the setting in the code is a Windows-specific setting. 

Leaving it uncommented on MacOS results in this error message:

terraform import docker_container.web $(docker inspect --format="{{.ID}}" hashicorp-learn)
2021-12-22T13:39:56.212-0800 [ERROR] vertex "provider[\"registry.terraform.io/kreuzwerker/docker\"]" error: Error initializing Docker client: protocol not available
╷
│ Error: Error initializing Docker client: protocol not available
│
│   with provider["registry.terraform.io/kreuzwerker/docker"],
│   on /Users/danstadler/Documents/code/terraform/terraform-associate/exam-review/learn-terraform-import/main.tf line 14, in provider "docker":
│   14: provider "docker" {
│
╵
